### PR TITLE
Enable Save as PDF on Chrome

### DIFF
--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -6,3 +6,4 @@
 @require "./content-types"
 @require "./slide-types"
 @require "./bespoke-modes"
+@require "./print"

--- a/src/styles/print.styl
+++ b/src/styles/print.styl
@@ -1,5 +1,5 @@
 @page
-    size $slide-width $slide-height
+    size $slide-width $slide-height+1px
     margin 0
     border 0
 

--- a/src/styles/print.styl
+++ b/src/styles/print.styl
@@ -1,5 +1,5 @@
 @page
-    size 1280px 721px
+    size $slide-width $slide-height
     margin 0
     border 0
 

--- a/src/styles/print.styl
+++ b/src/styles/print.styl
@@ -1,0 +1,26 @@
+@page
+    size 1280px 721px
+    margin 0
+    border 0
+
+@media print
+    .bespoke-slide
+        opacity 1
+        position relative
+        top inherit
+        bottom inherit
+        left inherit
+        right inherit
+        margin inherit
+        zoom 1 !important
+
+    .bespoke-parent
+        position relative
+        top inherit
+        bottom inherit
+        left inherit
+        right inherit
+        margin inherit
+
+    .bespoke-bullet-inactive
+        visibility visible


### PR DESCRIPTION
The print.styl stylesheet fixes the layout when you use the "Save as PDF" feature on Chrome.

Try it it's cool! And it works much better than PhantomJS based tools with flex-box.